### PR TITLE
Add get_checkins endpoint

### DIFF
--- a/internal/server/handleGetCheckins.go
+++ b/internal/server/handleGetCheckins.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (s *Server) handleGetCheckins(res http.ResponseWriter, req *http.Request) {
+
+	checkins, err := s.recurseClient.CurrentCheckins()
+	if err != nil {
+		s.logger.Error("could not get checkins", "error", err)
+		http.Error(res, "could not get checkins", http.StatusInternalServerError)
+		return
+	}
+
+	b, err := json.Marshal(checkins)
+	if err != nil {
+		s.logger.Error("json marshal failed", "error", err)
+		http.Error(res, "json marshal failed", http.StatusInternalServerError)
+		return
+	}
+
+	res.Header().Set("Content-Type", "application/json")
+	res.WriteHeader(http.StatusOK)
+	res.Write(b)
+}

--- a/internal/server/openapi.json
+++ b/internal/server/openapi.json
@@ -60,6 +60,46 @@
           }
         }
       }
+    },
+    "/api/v1/get_checkins": {
+      "get": {
+        "summary": "Get Checkins",
+        "description": "Get checkin data",
+        "operationId": "getChekins",
+        "tags": ["checkins"],
+        "responses": {
+          "200": {
+            "description": "Checkins processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCheckinResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -71,6 +111,22 @@
       "CheckinResponse": {
         "type": "object",
         "properties": {}
+      },
+      "GetCheckinResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "created_at": {"type": "string"},
+            "person": {
+              "type": "object",
+              "properties": {
+                "id": {"type": "number"},
+                "name": {"type": "string"}
+              }
+            }
+          }
+        }
       },
       "ErrorResponse": {
         "type": "object",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,6 +54,7 @@ func (s *Server) ListenAndServe(ctx context.Context, addr string) error {
 	}
 
 	mux.HandleFunc("POST /api/v1/print_checkins", s.handlePrintCheckins)
+	mux.HandleFunc("GET /api/v1/get_checkins", s.handleGetCheckins)
 
 	// apply middlewares
 	handler := middleware.Chain(mux,


### PR DESCRIPTION
```console
josh@nixos:~$ curl -vv http://127.0.0.1:8080/api/v1/get_checkins 
15:50:05.427104 [0-0] * [SETUP] added
15:50:05.427146 [0-0] *   Trying 127.0.0.1:8080...
15:50:05.427224 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
15:50:05.427240 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=1
15:50:05.427248 [0-0] * Connected to 127.0.0.1 (127.0.0.1) port 8080
15:50:05.427256 [0-0] * using HTTP/1.x
15:50:05.427282 [0-0] > GET /api/v1/get_checkins HTTP/1.1
15:50:05.427282 [0-0] > Host: 127.0.0.1:8080
15:50:05.427282 [0-0] > User-Agent: curl/8.14.1
15:50:05.427282 [0-0] > Accept: */*
15:50:05.427282 [0-0] > 
15:50:05.427362 [0-0] * Request completely sent off
15:50:05.896004 [0-0] < HTTP/1.1 200 OK
15:50:05.896097 [0-0] < Content-Type: application/json
15:50:05.896159 [0-0] < Date: Tue, 19 Aug 2025 19:50:05 GMT
15:50:05.896228 [0-0] < Transfer-Encoding: chunked
15:50:05.896290 [0-0] < 
[{"person":{"id":1234,"name":"someone's name"},"created_at":"2025-08-18T20:28:14-04:00"},... ]
```
